### PR TITLE
Fix logging

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -17,7 +17,7 @@ config = context.config
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.
 if config.config_file_name is not None:
-    fileConfig(config.config_file_name)
+    fileConfig(config.config_file_name, disable_existing_loggers=False)
 
 # add your model's MetaData object here
 # for 'autogenerate' support


### PR DESCRIPTION
## Summary
When using a custom FastAPI lifespan to run alembic migrations on startup, logging stops working.
Alembic, by default, disables existing loggers.
This PR overrides the default behavior of alembic.

## Changes made
- Added `disable_existing_loggers=False` to `fileConfig` in `alembic/env.py`

Closes #45
